### PR TITLE
removed suggestions to put config variables into variables file

### DIFF
--- a/content/customize/configure/index.mdx
+++ b/content/customize/configure/index.mdx
@@ -13,7 +13,7 @@ Here is an overview of what could be achieved through configuration in NRP-based
 Invenio RDM configuration is based on Flask application configuration system. For more details on how to configure an InvenioRDM application, please refer to the
 [InvenioRDM Configuration Documentation](https://inveniordm.docs.cern.ch/operate/customize/look-and-feel/#setting-configuration-values).
 
-NRP-based repositories use the same mechanisms for configuration as InvenioRDM applications. You can set configuration values in the primary Invenio configuration file -- `invenio.cfg`, via environment variables (prefixed by `INVENIO_`), or `variables` file located in the root of your repository project.
+NRP-based repositories use the same mechanisms for configuration as InvenioRDM applications. You can set configuration values in the primary Invenio configuration file `invenio.cfg`, or via environment variables (prefixed by `INVENIO_`).
 
 On top of that, a helper [config module](https://github.com/oarepo/oarepo/tree/rdm-14/oarepo/config) is available for you to use in your `invenio.cfg` file to help you configure NRP-specific features by a preset-based configuration approach.
 
@@ -57,7 +57,7 @@ They can be used in your `invenio.cfg` file to quickly configure various aspects
 
 Common helpers are provided for NRP repositories by the [oarepo.config](https://github.com/oarepo/oarepo/tree/rdm-14/oarepo/config) Python module.
 
-All helpers set configuration constants in the caller module (typically `invenio.cfg`) using `oarepo.config.base.set_constants_in_caller` and read environment/variables via `oarepo.config.base.load_configuration_variables` where applicable.
+All helpers set configuration constants in the caller module (typically `invenio.cfg`) using `oarepo.config.base.set_constants_in_caller` and read environment variables via `oarepo.config.base.load_configuration_variables` where applicable.
 
 ---
 

--- a/content/customize/repository_ui/branding/assets.mdx
+++ b/content/customize/repository_ui/branding/assets.mdx
@@ -1,4 +1,4 @@
-import { Tabs, Steps, Callout } from "nextra/components";
+import { Steps, Callout } from "nextra/components";
 import { Difficulty } from '@/components/difficulty'
 
 # Images & other assets <Difficulty level="easy" />
@@ -53,18 +53,9 @@ cp my-logo.svg myrepo/static/images/invenio-rdm.svg"
 ### Configure theme to use your logo
 
 
-<Tabs items={["invenio.cfg", "variables"]}>
-  <Tabs.Tab>
-```python copy
+```python filename="invenio.cfg" copy
 THEME_LOGO="images/my-logo.svg"
 ```
-  </Tabs.Tab>
-   <Tabs.Tab>
-```python copy
-INVENIO_THEME_LOGO="images/my-logo.svg"
-```
-  </Tabs.Tab>
-</Tabs>
 
 <Callout type="info" emoji="ℹ️">The path is always relative to the `static/` directory. So if your logo is at `myrepo/static/images/my-logo.svg`, you should set the config value to `images/my-logo.svg`.</Callout>
 </Steps>

--- a/content/customize/repository_ui/branding/copywriting.mdx
+++ b/content/customize/repository_ui/branding/copywriting.mdx
@@ -1,4 +1,3 @@
-import { Tabs } from "nextra/components";
 import { Difficulty } from "@/components/difficulty"
 
 # Copywriting <Difficulty level="easy" />
@@ -15,44 +14,26 @@ Learn how to update titles appearing throughout your NRP repository site with ea
 
 This setting determines the name of the site to be displayed on the header and used as a page title.
 
-<Tabs items={["invenio.cfg", "variables"]}>
-  <Tabs.Tab>
-```python copy
+```python filename="invenio.cfg" copy
 config.configure_ui(
     # ...
     name=_("My new NRP repository!"),
     # ...
 )
 ```
-  </Tabs.Tab>
-   <Tabs.Tab>
-```python copy
-INVENIO_REPOSITORY_NAME = 'My new NRP repository!';
-```
-  </Tabs.Tab>
-</Tabs>
 
 ### Title page repository description
 
 The title shown on the front page of the repository site.
 
 
-<Tabs items={["invenio.cfg", "variables"]}>
-  <Tabs.Tab>
-```python copy
+```python filename="invenio.cfg" copy
 config.configure_ui(
     # ...
     description=_("My Repository site description"),
     # ...
 )
 ```
-  </Tabs.Tab>
-   <Tabs.Tab>
-```python copy
-INVENIO_REPOSITORY_DESCRIPTION = 'My Repository site description';
-```
-  </Tabs.Tab>
-</Tabs>
 
 There are more texts configurable via Invenio application configuration variables. For more info, please consult the [Configuration Reference](/customize/configure/reference).
 

--- a/content/customize/repository_ui/branding/templating.mdx
+++ b/content/customize/repository_ui/branding/templating.mdx
@@ -1,5 +1,5 @@
 import { Difficulty } from "@/components/difficulty";
-import { Callout, FileTree, Cards, Steps, Tabs } from "nextra/components";
+import { Callout, FileTree, Cards, Steps } from "nextra/components";
 
 # Templating <Difficulty level="easy" />
 
@@ -129,18 +129,9 @@ In NRP Invenio repositories, most templates follow this pattern, allowing you to
 
 ### 2. Configure Your Repository to Use the Custom Footer
 
-<Tabs items={["invenio.cfg", "variables"]}>
-  <Tabs.Tab>
-```python copy
+```python filename="invenio.cfg" copy
 THEME_FOOTER_TEMPLATE="custom/myfooter.html"
 ```
-  </Tabs.Tab>
-   <Tabs.Tab>
-```python copy
-INVENIO_THEME_FOOTER_TEMPLATE="custom/myfooter.html"
-```
-  </Tabs.Tab>
-</Tabs>
 </Steps>
 
 This just scratches the surface of what you can achieve with templating in NRP Invenio repositories. For a more in-depth Jinja template development


### PR DESCRIPTION
I think it makes sense to remove discussions about putting variables such as THEME_LOGO into variables file:

a. There is no reason to give people multiple choices 
b. There is a possibility that the variable will not behave as expected in deployment

Throughout the years, I've never used variables file for this and I don't think there is a valid reason to do it. 

