### PR TITLE
fix(docs): add super() to webpack entry example

### DIFF
--- a/content/customize/repository_ui/js_assets/react/integration.mdx
+++ b/content/customize/repository_ui/js_assets/react/integration.mdx
@@ -127,10 +127,11 @@ theme = WebpackThemeBundle(
 
 Include the bundled JavaScript in your Jinja template:
 
-```jinja filename="ui/components/templates/home.jinja"{4}
+```jinja filename="ui/components/templates/home.jinja"{5}
 <div id="welcome-banner" data-user='{{ user | tojson }}'></div>
 
 {%- block javascript %}
+{{ super() }}
 {{ webpack['welcome_banner.js'] }}
 {%- endblock %}
 ```


### PR DESCRIPTION
## Summary

Add `{{ super() }}` directly to the main webpack entry example in the React integration documentation.

## Why

- This is the recommended pattern when inheriting templates that also define JavaScript blocks
- Previously shown only in an info callout below; now part of the primary example
- Ensures parent template JavaScript bundles (search UI, theme scripts, etc.) are preserved

## Changes

- `content/customize/repository_ui/js_assets/react/integration.mdx` - Updated the main template example

🤖 Generated with [Claude Code](https://claude.com/claude-code)